### PR TITLE
Remove repository field from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,6 @@
         "ext-pcre": "*",
         "php": ">=5.6.0"
     },
-    "repositories": {
-        "type": "vcs",
-        "url": "https://github.com/phlylabs/idna-convert.git"
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"


### PR DESCRIPTION
The reprository field in the composer.json is used to set alternative
repositories for root dependencies. The current value is invalid, as
it violates the schema (https://getcomposer.org/doc/04-schema.md#repositories)
and is used for information that does not belong in this field. (It is
redundant, since the package is registered on packagist.org)