### PR TITLE
update branch alias to 1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
or the branch alias should be dropped at all, better release often than rely on branch alias, which as you see got already outdated.